### PR TITLE
Updated project to work as expected

### DIFF
--- a/conf/base/catalog_02_int.yml
+++ b/conf/base/catalog_02_int.yml
@@ -1,0 +1,31 @@
+# THIS IS THE MANUAL EQUIVALENT OF THE PROFILING HOOK
+
+# ### HTML ###
+# test.html_profile:
+#   type: text.TextDataSet
+#   filepath: data/02_intermediate/test.html
+
+# train.html_profile:
+#   type: text.TextDataSet
+#   filepath: data/02_intermediate/train.html
+
+# ### JSON ###
+# test.json_profile:
+#   type: json.JSONDataSet
+#   filepath: data/02_intermediate/test.json
+
+# train.json_profile:
+#   type: json.JSONDataSet
+#   filepath: data/02_intermediate/train.json
+
+# ### PICKLE ###
+# test.pickled:
+#   type: pickle.PickleDataSet
+#   filepath: data/02_intermediate/test.pkl
+
+# train.pickled:
+#   type: pickle.PickleDataSet
+#   filepath: data/02_intermediate/train.pkl
+
+
+

--- a/conf/base/parameters/raw_data_load.yml
+++ b/conf/base/parameters/raw_data_load.yml
@@ -6,3 +6,11 @@
 tables:
   - train
   - test
+  # - one # If you comment this out and try Kedro Viz this will work for any number of arguments so long as they actually exist as raw inputs
+  # - two
+  # - three
+  # - four
+  # - five
+  # - six
+  # - seven
+  

--- a/src/test_project/hooks.py
+++ b/src/test_project/hooks.py
@@ -6,6 +6,10 @@ from kedro.framework.hooks import hook_impl
 from kedro.io import DataCatalog
 from kedro.versioning import Journal
 
+from kedro.extras.datasets.pickle import PickleDataSet, pickle_dataset
+from kedro.extras.datasets.json import JSONDataSet
+from kedro.extras.datasets.text import TextDataSet
+
 
 class ProjectHooks:
     @hook_impl
@@ -26,3 +30,25 @@ class ProjectHooks:
         return DataCatalog.from_config(
             catalog, credentials, load_versions, save_version, journal
         )
+
+
+class ProfilingHooks:
+
+    @hook_impl
+    def after_catalog_created(self, catalog, conf_catalog, conf_creds, feed_dict, save_version, load_versions, run_id):
+        """This is an advanced use of the catalog hook so that we create the right
+        catalog entries at runtime based on the inputs to the `params:tables`. The alternative
+        to this is that your non-technical users would have to create the three output
+        dataset entries in the catalog for every input they declare
+        """
+
+        profiling_output_tables = feed_dict['params:tables']
+        folder = 'data/02_intermediate'
+
+        for table in profiling_output_tables:
+            new_entries = {
+                f"{table}.html_profile" : TextDataSet(f"{folder}/{table}.html"),
+                f"{table}.json_profile" : JSONDataSet(f"{folder}/{table}.json"),
+                f"{table}.pickled" : PickleDataSet(f"{folder}/{table}.pkl")
+            }
+            catalog.add_all(new_entries, replace=True)

--- a/src/test_project/pipelines/raw_data_load/nodes.py
+++ b/src/test_project/pipelines/raw_data_load/nodes.py
@@ -3,23 +3,21 @@ This is a boilerplate pipeline 'raw_data_load'
 generated using Kedro 0.17.6
 """
 
-from typing import List
+from typing import Any, Dict, List, Tuple
 from pandas_profiling import ProfileReport
 
 import pandas as pd
-import json
+
 
 def create_descriptives(
-    data: pd.DataFrame, 
-    table_name: str
-) -> Dict[str, Any], str, pd.DataFrame: 
+    data: pd.DataFrame, table_name: str
+) -> Tuple[Dict[str, Any], str, pd.DataFrame]:
 
     profile = ProfileReport(
-        data, title=f"{table_name} Profiling Report", 
-        config_file="config_minimal.yml"
+        data, title=f"{table_name} Profiling Report", config_file="config_minimal.yml"
     )
 
     profile_json = profile.to_json()
     profile_html_string = profile.to_html()
 
-    return profile_json, profile_html_string, data 
+    return profile_json, profile_html_string, data

--- a/src/test_project/pipelines/raw_data_load/nodes.py
+++ b/src/test_project/pipelines/raw_data_load/nodes.py
@@ -12,23 +12,14 @@ import json
 def create_descriptives(
     data: pd.DataFrame, 
     table_name: str
-): 
+) -> Dict[str, Any], str, pd.DataFrame: 
 
-    #print(table_name)
-    # Create the profiling report
     profile = ProfileReport(
         data, title=f"{table_name} Profiling Report", 
         config_file="config_minimal.yml"
     )
 
-    # Save the report as an HTML file and JSON for further usage
-    profile.to_file(f"data/descriptives/{table_name}.html") 
-    # It doesn't save this as data/descriptives/train.html but instead it saves the whole dataframe
-    # I really dont know why
-    
-    json_data = json.loads(profile.to_json())
+    profile_json = profile.to_json()
+    profile_html_string = profile.to_html()
 
-    with open(f"data/02_intermediate/{table_name}.json", "w") as file:
-        json.dump(json_data, file)
-
-    return json_data
+    return profile_json, profile_html_string, data 

--- a/src/test_project/pipelines/raw_data_load/pipeline.py
+++ b/src/test_project/pipelines/raw_data_load/pipeline.py
@@ -24,7 +24,7 @@ def base_pipeline():
         ]
     )
 
-def create_pipeline(**kwargs):
+def create_pipeline(**kwargs) -> Pipeline:
 
     conf_paths = ["conf/base", "conf/local"]
     conf_loader = ConfigLoader(conf_paths)
@@ -40,12 +40,14 @@ def create_pipeline(**kwargs):
                 "table_name": str(f"{table_name}"),
             },
             outputs = {
-                "json_data": f"json_{table_name}",
-                "html_data": f"json_{table_name}",
+                "json_data": f"{table_name}.json_profile",
+                "html_data": f"{table_name}.html_profile",
+                "output_data" : f"{table_name}.pickled"
             },
-            namespace = f"{table_name}",
+            namespace = table_name,
         )
         for table_name in sql_data
     ]
     
-    return Pipeline(table_pipelines)
+    # Second level of namespace nesting!
+    return pipeline(sum(table_pipelines), namespace='profiling')

--- a/src/test_project/pipelines/raw_data_load/pipeline.py
+++ b/src/test_project/pipelines/raw_data_load/pipeline.py
@@ -18,7 +18,7 @@ def base_pipeline():
             node(
                 func = create_descriptives,
                 inputs = ["data", "table_name"],
-                outputs = "json_data",
+                outputs = ["json_data", "html_data", "output_data"],
                 name = "create_descriptives"
             )
         ]
@@ -40,7 +40,8 @@ def create_pipeline(**kwargs):
                 "table_name": str(f"{table_name}"),
             },
             outputs = {
-                "json_data": f"json_{table_name}"
+                "json_data": f"json_{table_name}",
+                "html_data": f"json_{table_name}",
             },
             namespace = f"{table_name}",
         )

--- a/src/test_project/settings.py
+++ b/src/test_project/settings.py
@@ -1,8 +1,8 @@
 """Project settings."""
-from test_project.hooks import ProjectHooks
+from test_project.hooks import ProfilingHooks, ProjectHooks
 
 # Instantiate and list your project hooks here
-HOOKS = (ProjectHooks(),)
+HOOKS = (ProjectHooks(), ProfilingHooks())
 
 # List the installed plugins for which to disable auto-registry
 # DISABLE_HOOKS_FOR_PLUGINS = ("kedro-viz",)


### PR DESCRIPTION
1. Updated `nodes.py` to output the right data
2. Updated `pipelines.py` to override the right inputs/outputs and fixed some namespace mistakes.
3. Added manual example of `conf/base/catalog_02_int.yml` of what is needed to save the profiling outputs
4. Added `after_catalog_created` hook to so that you don't need to do step 3 manually.

![Dec-29-2021 18-28-25](https://user-images.githubusercontent.com/35801847/147692595-6101b9f1-7157-42ad-ab8e-2b30f989bff9.gif)

If you uncomment the examples in `conf/base/parameters/raw_data_load.yml`

You can see that the Viz will update to accomodate any number of profiling declarations (however this won't run since the inputs don't exist)

![image](https://user-images.githubusercontent.com/35801847/147692701-8d74a445-f060-4022-9771-db3a9c7f4531.png)

